### PR TITLE
add support for strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ var isArrowFnWithParensRegex = /^\([^\)]*\) *=>/;
 var isArrowFnWithoutParensRegex = /^[^=]*=>/;
 
 module.exports = function isArrowFunction(fn) {
-	if (!isCallable(fn)) { return false; }
-	var fnStr = fnToStr.call(fn);
-	return fnStr.length > 0 &&
-		!isNonArrowFnRegex.test(fnStr) &&
-		(isArrowFnWithParensRegex.test(fnStr) || isArrowFnWithoutParensRegex.test(fnStr));
+	var type = typeof fn;
+  if (!isCallable(fn) && type !== 'string') { return false; }
+  var fnStr = type === 'string' ? fn : fnToStr.call(fn);
+  return fnStr.length > 0 &&
+    !isNonArrowFnRegex.test(fnStr) &&
+    (isArrowFnWithParensRegex.test(fnStr) || isArrowFnWithoutParensRegex.test(fnStr));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -66,3 +66,12 @@ test('returns true for arrow functions', function (t) {
 	}
 	t.end();
 });
+
+test('return true for arrow function in string', function (t) {
+  if (arrowFuncs.length > 0) {
+    t.ok(isArrowFunction('(a, b) => a * b'), 'arrow function in string');
+  } else {
+    t.skip('arrow function is arrow function - this environment does not support ES6 arrow functions. Please run `node --harmony`, or use a supporting browser.');
+  }
+  t.end();
+});


### PR DESCRIPTION
add support for accepting string type and check against 

```js
var isArrowFunction = require('is-arrow-function');
console.log(isArrowFunction('(a, b) => a * b'));
// => true
```